### PR TITLE
Have Closable.close throw vs return

### DIFF
--- a/Sources/Closable.swift
+++ b/Sources/Closable.swift
@@ -1,4 +1,8 @@
 public protocol Closable {
     var closed: Bool { get }
-    func close() -> Bool
+    func close() throws
+}
+
+public enum ClosableError: ErrorProtocol {
+    case alreadyClosed
 }

--- a/Sources/Drain.swift
+++ b/Sources/Drain.swift
@@ -39,17 +39,14 @@ public final class Drain: DataRepresentable, Stream {
         self.init(for: buffer.data)
     }
 
-    public func close() -> Bool {
-        if closed {
-            return false
-        }
+    public func close() throws {
+        guard !closed else { throw ClosableError.alreadyClosed }
         closed = true
-        return true
     }
 
     public func receive(upTo byteCount: Int, timingOut deadline: Double = .never) throws -> Data {
         if byteCount >= buffer.count {
-            close()
+            try close()
             return buffer
         }
 

--- a/Sources/Drain.swift
+++ b/Sources/Drain.swift
@@ -40,7 +40,9 @@ public final class Drain: DataRepresentable, Stream {
     }
 
     public func close() throws {
-        guard !closed else { throw ClosableError.alreadyClosed }
+        guard !closed else {
+            throw ClosableError.alreadyClosed
+        }
         closed = true
     }
 


### PR DESCRIPTION
I realize close is a rather simple action, but it can still have multiple reasons to fail that a user may want to handle in different ways. For example, if the close failed because the `Closable` had already been closed, we may want to do something different than if the close failed due to a signal interruption or EIO error.
