### PR TITLE
Adding JSON type

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -1,0 +1,15 @@
+
+public enum JSON {
+
+    public enum Number {
+        case integer(Int)
+        case double(Double)
+    }
+    
+    case object([String: JSON])
+    case array([JSON])
+    case number(JSON.Number)
+    case string(String)
+    case boolean(Bool)
+    case null
+}


### PR DESCRIPTION
Adding a JSON type, so that JSON libraries don't need to be large monolithic codebases with a lot of duplication (basic types, conversion between Swift and JSON types, manipulation convenience functions, etc). Instead, one library will be able to focus just on e.g. parsing, another on pretty printing, another on providing a BSON representation and so on. The goal is to make all of them compatible and composable.
