### PR TITLE
RFC 7159 JSON Using External Number

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -1,0 +1,8 @@
+public enum JSON {
+    case object([String: JSON])
+    case array([JSON])
+    case number(Number)
+    case string(String)
+    case boolean(Bool)
+    case null
+}


### PR DESCRIPTION
This PR is failing cause it depends on https://github.com/open-swift/C7/pull/34
## Rationale

JSON's [RFC section](https://tools.ietf.org/html/rfc7159#section-6) about numbers doesn't enforce implementations to use double. They only mention the range and precision of the number being represented, and they even say it's up to the **implementation** how to define this.

> This specification allows implementations to set limits on the range
>    and precision of numbers accepted.

**V8 (Javascript)** uses int and double to represent JSON numbers.

https://github.com/v8/v8/blob/master/src/js/json.js#L216
https://github.com/v8/v8/blob/4afe89a7daba26f915f61765768b9d49295cf10e/src/factory.cc#L2215

Gson Java's implementation uses Java's `Number`

https://github.com/google/gson/blob/master/gson/src/main/java/com/google/gson/JsonPrimitive.java#L55

This C++'s implementation uses `number_integer_t`, `number_unsigned_t`, `number_float_t`

> ```
> This description includes both integer and floating-point numbers.
> However, C++ allows more precise storage if it is known whether the number
> is a signed integer, an unsigned integer or a floating-point number.
> Therefore, three different types, @ref number_integer_t, @ref
> number_unsigned_t and @ref number_float_t are used.
> ```

https://github.com/nlohmann/json/blob/develop/src/json.hpp#L472

Rust's standard library represents numbers in `i64`, `u64`,`f64`

``` rust
pub enum Json {
    I64(i64),
    U64(u64),
    F64(f64),
    String(string::String),
    Boolean(bool),
    Array(self::Array),
    Object(self::Object),
    Null,
}
```

https://github.com/rust-lang/rust/blob/master/src/libserialize/json.rs#L217

Scala uses BigDecimal:
https://github.com/spray/spray-json/blob/master/src/main/scala/spray/json/JsValue.scala#L88

Haskell uses Rational:
https://hackage.haskell.org/package/json-0.9.1/docs/Text-JSON.html

Dart uses `num`

> Both integers and doubles are sub-classes of the num class.

https://github.com/dart-lang/sdk/blob/master/sdk/lib/convert/json.dart#L556
https://www.dartlang.org/dart-tips/dart-tips-ep-4.html

This means we're free to represent numbers in the way that is best for the language, in our case, Swift. 

I propose we use `Number` instead of `Double`. Representing numbers as `Double`, if we want to use the number as an `Int` we have to cast it like so (given one is not using a higher level library with convenience computed properties).

``` swift
switch json {
  case .number(let number):
    functionThatExpectsInt(Int(number))
  ...
}
```

With `Number` it's the same thing.

``` swift
switch json {
  case .number(let number):
    functionThatExpectsInt(Int(number))
  ...
}
```

`Number` is more powerful cause it can remember the type that it was used to initialize it. This allows the serialization to keep the same number representation used in the parsing process. I reiterate what @czechboy0 said, using `Double` is more restrictive than using `Number` and there's no reason we should be more restrictive. Even more if we have evidence that other high profile type-safe languages uses other representations that is better suited for them.

This is a standard and a standard has to be based on facts not pure opinions. So here are some facts:
- JSON's RFC does not states that a number has to be represented as Double.
- Most higher level type-safe languages use their own abstraction for a number or use multiple primitives like int and double.
- Swift is known for it's type-safety
- Number can be used in a multitude of applications

On the other side of the argument there's one fact:
- Javascript uses double (but uses V8 uses `int` and `double` internally)
### Closing arguments

In my view `C7` should **allow** more and having `JSON` use number **allows** more. Having `Double` is more restrictive. So using `Number` would go with our first item in the mission statement.

> Inclusive
> Swift X standards should be unbiased and easy to adopt for all Swift projects.

While using `Double` would be against it. Cause it would make **impossible** to have the serializer output the same format in the input. In other words `Number` **is** inclusive, `Double` is **not**.
