### PR TITLE
RFC 7159 JSON Using Double

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -1,0 +1,8 @@
+public enum JSON {
+    case object([String: JSON])
+    case array([JSON])
+    case number(Double)
+    case string(String)
+    case boolean(Bool)
+    case null
+}


### PR DESCRIPTION
I believe this pull request for adding JSON support to C7 more accurately reflects the intentions of the Open Swift mission statement, and the RFC 7159 spec for JSON.

Excerpt from Open Swift Mission Statement:

```
Minimum viable requirements
Only the code that is absolutely necessary for cross-project compatibility will be included.
```

Excerpts from JSON spec:

```
A JSON value MUST be an object, array, number, or string, or one of
   the following three literal names:

      false null true
```

```
Since software that implements
   IEEE 754-2008 binary64 (double precision) numbers [IEEE754] is
   generally available and widely used, good interoperability can be
   achieved by implementations that expect no more precision or range
   than these provide
```

Related to #34 and #35.

Add a 👍 if you support this approach. If you disagree, add a comment or a new PR with your proposed alternate solution and give that a 👍 
