### PR TITLE
add structured data

### DIFF
--- a/Sources/StructuredData.swift
+++ b/Sources/StructuredData.swift
@@ -14,7 +14,7 @@ public enum StructuredData {
     case double(Double)
     case int(Int)
     case string(String)
-    case bytes(Data)
+    case data(Data)
     case array([StructuredData])
     case dictionary([String: StructuredData])
 }

--- a/Sources/StructuredData.swift
+++ b/Sources/StructuredData.swift
@@ -9,7 +9,7 @@ public protocol StructuredDataRepresentable {
 public protocol StructuredDataConvertible: StructuredDataInitializable, StructuredDataRepresentable {}
 
 public enum StructuredData {
-    case nullValue
+    case null
     case bool(Bool)
     case double(Double)
     case integer(Int)

--- a/Sources/StructuredData.swift
+++ b/Sources/StructuredData.swift
@@ -12,9 +12,9 @@ public enum StructuredData {
     case null
     case bool(Bool)
     case double(Double)
-    case integer(Int)
+    case int(Int)
     case string(String)
-    case binary(Data)
+    case bytes(Data)
     case array([StructuredData])
     case dictionary([String: StructuredData])
 }

--- a/Sources/StructuredData.swift
+++ b/Sources/StructuredData.swift
@@ -1,0 +1,20 @@
+public protocol StructuredDataInitializable {
+    init(structuredData: StructuredData) throws
+}
+
+public protocol StructuredDataRepresentable {
+    var structuredData: StructuredData { get }
+}
+
+public protocol StructuredDataConvertible: StructuredDataInitializable, StructuredDataRepresentable {}
+
+public enum StructuredData {
+    case nullValue
+    case bool(Bool)
+    case double(Double)
+    case integer(Int)
+    case string(String)
+    case binary(Data)
+    case array([StructuredData])
+    case dictionary([String: StructuredData])
+}


### PR DESCRIPTION
Almost every project that uses `Data` will require a higher level of abstraction for this data; whether it be database storage, content negotiation, or otherwise. 

`StructuredData` introduces an abstraction for representing data that can be as simple as a single `null` value to as complex as a multi-tiered JSON tree. 

Uses:
- Content Negotiation: structured data is incredibly useful for content negotiation. Parsers can read interchange formats directly into structured data which can then be mapped onto data types. The same goes for serialization.
- Database: storing and fetching data from databases like mongo or SQL have value types that could be contained as structured data. 
- More... 

By add a structured data abstraction to `C7`, we can promote cross project interoperability with more than just the current structureless `Data`. This could greatly decrease boilerplate code and potentially improve performance for common tasks like parsing and serializing JSON, or passing data between modules.

Add a 👍 if you support this PR, or recommend a different solution / create a better PR and give that a 👍. 
