### PR TITLE
RFC 7159 JSON Using Internal Number 

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -1,0 +1,15 @@
+
+public enum JSON {
+
+    public enum Number {
+        case integer(Int)
+        case double(Double)
+    }
+    
+    case object([String: JSON])
+    case array([JSON])
+    case number(JSON.Number)
+    case string(String)
+    case boolean(Bool)
+    case null
+}

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -1,11 +1,9 @@
-
 public enum JSON {
-
     public enum Number {
         case integer(Int)
+        case unsignedInteger(UInt)
         case double(Double)
     }
-    
     case object([String: JSON])
     case array([JSON])
     case number(JSON.Number)

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -11,3 +11,40 @@ public enum JSON {
     case boolean(Bool)
     case null
 }
+
+//
+// TODO: refactor with
+// https://github.com/apple/swift-evolution/blob/master/proposals/0080-failable-numeric-initializers.md
+//
+
+extension Int {
+    public init?(_ number: JSON.Number) {
+        switch number {
+        case let .integer(value)                                         : self.init(value)
+        case let .unsignedInteger(value) where value <= UInt(Int.max)    : self.init(value)
+        case let .double(value)          where value <= Double(Int32.max): self.init(value)
+        default: return nil
+        }
+    }
+}
+
+extension UInt {
+    public init?(_ number: JSON.Number) {
+        switch number {
+        case let .integer(value)         where value > 0                  : self.init(value)
+        case let .unsignedInteger(value)                                  : self.init(value)
+        case let .double(value)          where value <= Double(UInt32.max): self.init(value)
+        default: return nil
+        }
+    }
+}
+
+extension Double {
+    public init(_ number: JSON.Number) {
+        switch number {
+        case let .integer(value)        : self.init(value)
+        case let .unsignedInteger(value): self.init(value)
+        case let .double(value)         : self.init(value)
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/open-swift/C7/pull/32 afterparty 

Initializers allow writing this code:

``` swift
for item in json {
  guard case .number(let number) = item else {
    throw Error()
  }
  let double = Double(number)
  // do things 
}
```

instead of 

``` swift
for item in json {
  switch item {
  case .number(.double(let value)): // do things
  case .number(.integer(let value)): // do things
  case .number(.unsignedInteger(let value)): // do things
  default: throw Error()
  }
}
```

we should recommend using initializers to avoid this bug, when `1.0` double value send 
from the client-side becomes Integer, example in javascript: `JSON.stringify({num: 1.0})`
