### PR TITLE
RFC 7159 JSON Using Int and Double

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -1,0 +1,9 @@
+public enum JSON {
+    case object([String: JSON])
+    case array([JSON])
+    case integer(Int)
+    case double(Double)
+    case string(String)
+    case boolean(Bool)
+    case null
+}


### PR DESCRIPTION
For those of us who want something simple and Swifty:

``` swift
public enum JSON {
    case object([String: JSON])
    case array([JSON])
    case integer(Int)
    case double(Double)
    case string(String)
    case boolean(Bool)
    case null
}
```

Per Apple's official _The Swift Programming Language_ book, `Int` and `Double` are the most fundamental number types for Swift users and the most appropriate choice:

> Unless you need to work with a specific size of integer, always use Int for integer values in your code.
> 
> The appropriate floating-point type to use depends on the nature and range of values you need to work with in your code. In situations where either type would be appropriate, Double is preferred.
