### PR TITLE
Make AsyncDrain only take AsyncReceivingStream

### DIFF
--- a/Sources/AsyncDrain.swift
+++ b/Sources/AsyncDrain.swift
@@ -13,7 +13,7 @@ public final class AsyncDrain: DataRepresentable, AsyncStream {
         self.init(for: [])
     }
     
-    public init(for stream: AsyncStream, timingOut deadline: Double = .never, completion: ((Void) throws -> AsyncDrain) -> Void) {
+    public init(for stream: AsyncReceivingStream, timingOut deadline: Double = .never, completion: ((Void) throws -> AsyncDrain) -> Void) {
         var buffer: Data = []
         
         if stream.closed {


### PR DESCRIPTION
No need for it to be Sending as well, this respects the contract better.
