### PR TITLE
make completion closures @escaping

### DIFF
--- a/Sources/AsyncConnection.swift
+++ b/Sources/AsyncConnection.swift
@@ -1,9 +1,9 @@
 public protocol AsyncConnection: AsyncStream {
-    func open(timingOut deadline: Double, completion: ((Void) throws -> AsyncConnection) -> Void) throws
+    func open(timingOut deadline: Double, completion: @escaping ((Void) throws -> AsyncConnection) -> Void) throws
 }
 
 extension AsyncConnection {
-    public func open(completion: ((Void) throws -> AsyncConnection) -> Void) throws {
+    public func open(completion: @escaping ((Void) throws -> AsyncConnection) -> Void) throws {
         try open(timingOut: .never, completion: completion)
     }
 }

--- a/Sources/AsyncDrain.swift
+++ b/Sources/AsyncDrain.swift
@@ -1,4 +1,5 @@
 public final class AsyncDrain: DataRepresentable, AsyncStream {
+
     var buffer: Data = []
     public var closed = false
     
@@ -58,7 +59,7 @@ public final class AsyncDrain: DataRepresentable, AsyncStream {
         closed = true
     }
     
-    public func receive(upTo byteCount: Int, timingOut deadline: Double = .never, completion: ((Void) throws -> Data) -> Void) {
+    public func receive(upTo byteCount: Int, timingOut deadline: Double = .never, completion: @escaping ((Void) throws -> Data) -> Void) {
         if byteCount >= buffer.count {
             completion { [unowned self] in
                 try self.close()
@@ -75,12 +76,12 @@ public final class AsyncDrain: DataRepresentable, AsyncStream {
         }
     }
     
-    public func send(_ data: Data, timingOut deadline: Double = .never, completion: ((Void) throws -> Void) -> Void) {
+    public func send(_ data: Data, timingOut deadline: Double = .never, completion: @escaping ((Void) throws -> Void) -> Void) {
         buffer += data.bytes
         completion {}
     }
     
-    public func flush(timingOut deadline: Double = .never, completion: ((Void) throws -> Void) -> Void) {
+    public func flush(timingOut deadline: Double = .never, completion: @escaping ((Void) throws -> Void) -> Void) {
         buffer = []
         completion {}
     }

--- a/Sources/AsyncHost.swift
+++ b/Sources/AsyncHost.swift
@@ -1,9 +1,9 @@
 public protocol AsyncHost {
-    func accept(timingOut deadline: Double, completion: ((Void) throws -> AsyncStream) -> Void)
+    func accept(timingOut deadline: Double, completion: @escaping ((Void) throws -> AsyncStream) -> Void)
 }
 
 extension AsyncHost {
-    public func accept(completion: ((Void) throws -> AsyncStream) -> Void) {
+    public func accept(completion: @escaping ((Void) throws -> AsyncStream) -> Void) {
         accept(timingOut: .never, completion: completion)
     }
 }

--- a/Sources/AsyncStream.swift
+++ b/Sources/AsyncStream.swift
@@ -1,10 +1,10 @@
 public protocol AsyncSending {
-    func send(_ data: Data, timingOut deadline: Double, completion: ((Void) throws -> Void) -> Void)
-    func flush(timingOut deadline: Double, completion: ((Void) throws -> Void) -> Void)
+    func send(_ data: Data, timingOut deadline: Double, completion: @escaping ((Void) throws -> Void) -> Void)
+    func flush(timingOut deadline: Double, completion: @escaping  ((Void) throws -> Void) -> Void)
 }
 
 public protocol AsyncReceiving {
-    func receive(upTo byteCount: Int, timingOut deadline: Double, completion: ((Void) throws -> Data) -> Void)
+    func receive(upTo byteCount: Int, timingOut deadline: Double, completion: @escaping ((Void) throws -> Data) -> Void)
 }
 
 public protocol AsyncSendingStream: Closable, AsyncSending {}
@@ -12,16 +12,16 @@ public protocol AsyncReceivingStream: Closable, AsyncReceiving {}
 public protocol AsyncStream: AsyncSendingStream, AsyncReceivingStream {}
 
 extension AsyncSending {
-    public func send(_ data: Data, completion: ((Void) throws -> Void) -> Void) {
+    public func send(_ data: Data, completion: @escaping ((Void) throws -> Void) -> Void) {
         send(data, timingOut: .never, completion: completion)
     }
-    public func flush(completion: ((Void) throws -> Void) -> Void) {
+    public func flush(completion: @escaping ((Void) throws -> Void) -> Void) {
         flush(timingOut: .never, completion: completion)
     }
 }
 
 extension AsyncReceiving {
-    public func receive(upTo byteCount: Int, completion: ((Void) throws -> Data) -> Void) {
+    public func receive(upTo byteCount: Int, completion: @escaping ((Void) throws -> Data) -> Void) {
         receive(upTo: byteCount, timingOut: .never, completion: completion)
     }
 }

--- a/Sources/Stream.swift
+++ b/Sources/Stream.swift
@@ -12,11 +12,11 @@ public protocol ReceivingStream: Closable, Receiving {}
 public protocol Stream: SendingStream, ReceivingStream {}
 
 extension Sending {
-    public func send(_ data: Data, timingOut deadline: Double, completion: ((Void) throws -> Void) -> Void) {
+    public func send(_ data: Data, timingOut deadline: Double, completion: @escaping ((Void) throws -> Void) -> Void) {
         completion { try self.send(data, timingOut: deadline) }
     }
 
-    public func flush(timingOut deadline: Double, completion: ((Void) throws -> Void) -> Void) {
+    public func flush(timingOut deadline: Double, completion: @escaping ((Void) throws -> Void) -> Void) {
         completion { try self.flush(timingOut: deadline) }
     }
 }
@@ -32,7 +32,7 @@ extension Sending {
 }
 
 extension Receiving {
-    public func receive(upTo byteCount: Int, timingOut deadline: Double, completion: ((Void) throws -> Data) -> Void) {
+    public func receive(upTo byteCount: Int, timingOut deadline: Double, completion: @escaping ((Void) throws -> Data) -> Void) {
         completion { try self.receive(upTo: byteCount, timingOut: deadline) }
     }
 }


### PR DESCRIPTION
This PR adds `@escaping` annotation to the AsyncX completion closures cause Swift made nonescape  closures default(https://github.com/apple/swift/pull/4052).
Almost async functions need to call `completion` in nested closures that are made with file system, netwroking operations etc...
